### PR TITLE
Update useIntersectionObserver to re-observe when it mount

### DIFF
--- a/src/useIntersectionObserver.ts
+++ b/src/useIntersectionObserver.ts
@@ -48,13 +48,6 @@ function useIntersectionObserver(
     observerRef.current = null;
   }, []);
 
-  useEffect(() => {
-    return () => {
-      // We disconnect the observer on unmount to prevent memory leaks etc.
-      unobserve();
-    };
-  }, [unobserve]);
-
   const observe = useCallback(() => {
     const node = nodeRef.current;
     if (node) {
@@ -89,6 +82,15 @@ function useIntersectionObserver(
     },
     [initializeObserver],
   );
+
+  useEffect(() => {
+    initializeObserver();
+
+    return () => {
+      // We disconnect the observer on unmount to prevent memory leaks etc.
+      unobserve();
+    };
+  }, [initializeObserver, unobserve]);
 
   return [refCallback, { entry, rootRef: rootRefCallback }];
 }


### PR DESCRIPTION
### Descriptions
- I found out that [Strict Effect](https://github.com/reactwg/react-18/discussions/19) is added to `React.StrictMode` in react 18
- It triggers useEffect is run twice in development environment. So, when react strictMode is enabled, this hook is not working as expected. Because useEffect calls only unobserve when component unmounts and does not call observe when component re-mounts.
- React team says code should be fine even if it mounts and unmounts couple of times. They also say useEffect might be called and useEffect destructor might be called too when user go to another tab or somthing. I think it is related to offscreen api.  So, I thought this hook also should be written in the way they suggest.
- The above is why I made this pr. Please check out this pr.